### PR TITLE
feat: add 1321 solution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,5 @@ repos:
     rev: v0.8.1
     hooks:
       - id: ruff
-        args: ["check", "--fix"]
+        args: ["check", "--select", "I", "--fix"]
       - id: ruff-format

--- a/problem_1321_data.py
+++ b/problem_1321_data.py
@@ -1,0 +1,30 @@
+# noqa D100
+
+import pandas as pd
+import pyarrow as pa
+
+data = [
+    [1, "Jhon", "2019-01-01", 100],
+    [2, "Daniel", "2019-01-02", 110],
+    [3, "Jade", "2019-01-03", 120],
+    [4, "Khaled", "2019-01-04", 130],
+    [5, "Winston", "2019-01-05", 110],
+    [6, "Elvis", "2019-01-06", 140],
+    [7, "Anna", "2019-01-07", 150],
+    [8, "Maria", "2019-01-08", 80],
+    [9, "Jaze", "2019-01-09", 110],
+    [1, "Jhon", "2019-01-10", 130],
+    [3, "Jade", "2019-01-10", 150],
+]
+customer = pd.DataFrame(
+    data, columns=["customer_id", "name", "visited_on", "amount"]
+).astype(
+    {
+        "customer_id": "Int64",
+        "name": "object",
+        "visited_on": "datetime64[ns]",
+        "amount": "Int64",
+    }
+)
+
+table = pa.table(customer)

--- a/problems/leetcode.py
+++ b/problems/leetcode.py
@@ -1064,7 +1064,48 @@ def problem_1321(customer: pa.Table) -> pa.Table:
     pa.Table
 
     """
-    pass
+    customer = customer.set_column(
+        customer.schema.get_field_index("visited_on"),
+        "visited_on",
+        pc.strptime(customer["visited_on"], format="%Y-%m-%d", unit="s"),
+    )
+
+    grouped = customer.group_by(["visited_on"]).aggregate([("amount", "sum")])
+
+    dates = grouped["visited_on"]
+    amounts = grouped["amount_sum"]
+
+    rolling_sums = []
+    rolling_averages = []
+
+    for i in range(len(dates)):
+        window_start = pc.subtract(
+            dates[i], pa.scalar(7 * 24 * 60 * 60, type=pa.duration("s"))
+        )
+        mask = pc.and_(
+            pc.greater_equal(dates, window_start),
+            pc.less_equal(dates, dates[i]),
+        )
+        filtered_amounts = pc.filter(amounts, mask)
+        rolling_sum = pc.sum(filtered_amounts).as_py()
+        rolling_avg = round(rolling_sum / 7, 2)
+
+        rolling_sums.append(rolling_sum)
+        rolling_averages.append(rolling_avg)
+
+    grouped = grouped.append_column("rolling_sum", pa.array(rolling_sums))
+    grouped = grouped.append_column(
+        "average_amount", pa.array(rolling_averages, type=pa.float64())
+    )
+
+    final_result = grouped.slice(6)
+
+    final_result = final_result.select(["visited_on", "rolling_sum", "average_amount"])
+    final_result = final_result.rename_columns(
+        ["visited_on", "amount", "average_amount"]
+    )
+
+    return final_result
 
 
 def problem_1327(products: pa.Table, orders: pa.Table) -> pa.Table:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
   {name = "Tyler White"},
 ]
 dependencies = [
-  "pyarrow==18.1.0"
+  "datafusion>=42.0.0",
+  "pyarrow==18.1.0",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/tests/test_leetcode.py
+++ b/tests/test_leetcode.py
@@ -1700,6 +1700,48 @@ def test_problem_1280(input_data_1, input_data_2, input_data_3, expected_data):
             },
             id="happy_path",
         ),
+        pytest.param(
+            {
+                "customer_id": [1, 2, 3, 1, 4, 5, 6, 1, 7, 8, 9],
+                "name": [
+                    "Jhon",
+                    "Daniel",
+                    "Jade",
+                    "Jhon",
+                    "Khaled",
+                    "Winston",
+                    "Elvis",
+                    "Jhon",
+                    "Anna",
+                    "Maria",
+                    "Jaze",
+                ],
+                "visited_on": [
+                    datetime(2019, 1, 1),
+                    datetime(2019, 1, 2),
+                    datetime(2019, 1, 3),
+                    datetime(2019, 1, 1),
+                    datetime(2019, 1, 4),
+                    datetime(2019, 1, 5),
+                    datetime(2019, 1, 6),
+                    datetime(2019, 1, 1),
+                    datetime(2019, 1, 7),
+                    datetime(2019, 1, 8),
+                    datetime(2019, 1, 9),
+                ],
+                "amount": [100, 110, 120, 50, 130, 110, 140, 40, 150, 80, 110],
+            },
+            {
+                "visited_on": [
+                    datetime(2019, 1, 7),
+                    datetime(2019, 1, 8),
+                    datetime(2019, 1, 9),
+                ],
+                "amount": [950, 840, 840],
+                "average_amount": [135.71, 120, 120],
+            },
+            id="duplicated_days",
+        ),
     ],
 )
 def test_problem_1321(input_data, expected_data):

--- a/uv.lock
+++ b/uv.lock
@@ -107,6 +107,23 @@ wheels = [
 ]
 
 [[package]]
+name = "datafusion"
+version = "42.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyarrow" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/46/cf91530c06a11a699e177aa02716531f31a009087827e6d71f47d0d8b86e/datafusion-42.0.0.tar.gz", hash = "sha256:c88955a9ac59504d9d302be03158e692b9f99c3bf53dca0e84252d81f8c5ca91", size = 135459 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/2d/86a0e94e2efd7e87a83a3510d05ce71655bc02bf40aadb0286e08dea66c6/datafusion-42.0.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e9506356ad5d5f7b0f2d636cea24c5fc72518305aacf81207ecb4d59d0ea6866", size = 19496219 },
+    { url = "https://files.pythonhosted.org/packages/70/f4/b1270af3a0d0ec23f5cd593ec4ee7878b313dd0eb5b2ab4ec2eedcfa153a/datafusion-42.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:63a07e3779d3bdca0ecafd2eedf6948feff3ecd496a1fcf93baac122a48c6f4f", size = 17817291 },
+    { url = "https://files.pythonhosted.org/packages/3a/53/7dd8a09dd759aa8ca1ebd0eef9dd36e741e046c1b9315c2d6257f0119dde/datafusion-42.0.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4f04adbef61e70a3f56c6fcf6b615f75bbc42610947092870acff03171a456b", size = 21748992 },
+    { url = "https://files.pythonhosted.org/packages/5a/60/73945d35d612f09bf802269f1aaa57d6a3c6472a36b14ac4d8ac65529b5e/datafusion-42.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1fb4a7f34225948d7a5db2ee3b3a578dd6b95c2bae39fd940dfd2de90a34088d", size = 20612406 },
+    { url = "https://files.pythonhosted.org/packages/d6/cc/f30443b500326a97def2ee17e972883ebf9048a89cd705ed6e4bec201c1a/datafusion-42.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:71d9af5a9a6852f8121e4811a913cfec596f4c36240149edea57d27af7318749", size = 21140655 },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.9"
 source = { registry = "https://pypi.org/simple" }
@@ -468,6 +485,7 @@ name = "pyarrow-exercises"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "datafusion" },
     { name = "pyarrow" },
 ]
 
@@ -481,6 +499,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "datafusion", specifier = ">=42.0.0" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = "==6.29.5" },
     { name = "ipython", marker = "extra == 'dev'", specifier = "==8.30.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.0.1" },


### PR DESCRIPTION
Starting this so that I can at least start progressing on it. My pandas solution is:

```py
import pandas as pd

def restaurant_growth(customer: pd.DataFrame) -> pd.DataFrame:
    grouped = customer.groupby(["visited_on"]).aggregate(
        amount=pd.NamedAgg("amount", "sum")
    )
    grouped = (
        grouped.assign(amount=grouped["amount"].rolling("7D").sum())
        .reset_index()
        .loc[6:]
    )
    return grouped.assign(average_amount=(grouped["amount"] / 7).round(2))
 ```

The issue I'm having with the current solution is:

```txt
     20     customer = customer.set_column(
     21         customer.schema.get_field_index("visited_on"),
     22         "visited_on",
---> 23         pc.strptime(customer["visited_on"], format="%Y-%m-%d", unit="s"),
     24     )
     26     grouped = customer.group_by(["visited_on"]).aggregate([("amount", "sum")])
     28     dates = grouped["visited_on"]

File ~/Documents/GitHub/pyarrow-exercises/.venv/lib/python3.12/site-packages/pyarrow/compute.py:264, in _make_generic_wrapper.<locals>.wrapper(memory_pool, options, *args, **kwargs)
    262 if args and isinstance(args[0], Expression):
    263     return Expression._call(func_name, list(args), options)
--> 264 return func.call(args, options, memory_pool)

File ~/Documents/GitHub/pyarrow-exercises/.venv/lib/python3.12/site-packages/pyarrow/_compute.pyx:393, in pyarrow._compute.Function.call()

File ~/Documents/GitHub/pyarrow-exercises/.venv/lib/python3.12/site-packages/pyarrow/error.pxi:155, in pyarrow.lib.pyarrow_internal_check_status()

File ~/Documents/GitHub/pyarrow-exercises/.venv/lib/python3.12/site-packages/pyarrow/error.pxi:92, in pyarrow.lib.check_status()

ArrowNotImplementedError: Function 'strptime' has no kernel matching input types (timestamp[ns])
```